### PR TITLE
include query params with all api requests

### DIFF
--- a/lib/MailchimpMarketing/api_client.rb
+++ b/lib/MailchimpMarketing/api_client.rb
@@ -64,7 +64,7 @@ module MailchimpMarketing
       res = nil
       case http_method.to_sym.downcase
       when :post, :put, :patch, :delete
-        res = conn.request(:method => http_method, :body => opts[:body])
+        res = conn.request(:method => http_method, :query => opts[:query_params], :body => opts[:body])
       when :get
         res = conn.get(:query => opts[:query_params])
       end


### PR DESCRIPTION
Currently, `POST`, `PUT`, `PATCH`, and `DELETE` requests are not including any query string params when requesting the API.

I discovered this bug when trying to pass a `skip_merge_validation` query string param, and it wasn't being sent to the API. But as you can see from the PR, this bug is present on all non-`GET` requests.

I didn't see any contributing guidelines, and the codebase has no tests, but hopefully this PR is acceptable. Let me know if you'd like anything changed.