### PR TITLE
Fix warning when running gem build

### DIFF
--- a/MailchimpMarketing.gemspec
+++ b/MailchimpMarketing.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.12'
 
   s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
-  s.test_files    = `find spec/*`.split("\n")
+  s.test_files    = []
   s.executables   = []
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
Since there's no spec directory, when running `gem build` (or installing this gem via git source), following warning is shown:

`find: spec/*: No such file or directory`
