### PR TITLE
Remove incorrect version number from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Mailchimp Marketing — Ruby
 
-The official Ruby client library for the Mailchimp Marketing API (v1)
+The official Ruby client library for the Mailchimp Marketing API
 
 ## Installation
 


### PR DESCRIPTION
This is for API V3 (not V1).

The other client libraries ([python](https://github.com/mailchimp/mailchimp-marketing-python), [node](https://github.com/mailchimp/mailchimp-marketing-node), [php](https://github.com/mailchimp/mailchimp-marketing-php)) don't specify versions at the top of the readme, so might as well follow that convention.